### PR TITLE
fix: crash on null values from access long type

### DIFF
--- a/pandas_access/__init__.py
+++ b/pandas_access/__init__.py
@@ -34,7 +34,8 @@ def _extract_dtype(data_type):
     if data_type.startswith('double'):
         return np.float_
     elif data_type.startswith('long'):
-        return np.int_
+        # access CAN have null values on long type, @ pandas 0.24 int null suport is experimental, a float is safer for now.
+        return np.float_
     else:
         return None
 


### PR DESCRIPTION
Changed the conversion from access long type to pandas float instead of pandas int, in order to support null values.

Note that pandas just released int null support @ pandas .24, but still experimental.