### PR TITLE
changes to support names with spaces

### DIFF
--- a/pandas_access/__init__.py
+++ b/pandas_access/__init__.py
@@ -8,10 +8,10 @@ except ImportError:
     from io import BytesIO
 
 
-TABLE_RE = re.compile("CREATE TABLE \[(\w+)\]\s+\((.*?\));",
+TABLE_RE = re.compile("CREATE TABLE \[([^]]+)\]\s+\((.*?\));",
                       re.MULTILINE | re.DOTALL)
 
-DEF_RE = re.compile("\s*\[(\w+)\]\s*(.*?),")
+DEF_RE = re.compile("\s*\[([^]]+)\]\s*(.*?),")
 
 
 def list_tables(rdb_file, encoding="latin-1"):
@@ -22,8 +22,8 @@ def list_tables(rdb_file, encoding="latin-1"):
         actually be UTF-8.
     :return: A list of the tables in a given database.
     """
-    tables = subprocess.check_output(['mdb-tables', rdb_file]).decode(encoding)
-    return tables.strip().split(" ")
+    tables = subprocess.check_output(['mdb-tables', "-1", rdb_file]).decode(encoding)
+    return tables.strip().split("\n")
 
 
 def _extract_dtype(data_type):


### PR DESCRIPTION
As written on the tin; impetus was accessing (sic) the NY State Education Department's school report card database, which is distributed as an Access database whose the table names include spaces.