### PR TITLE
Integer NA exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ $ brew install mdbtools
 ```
 Then, do,
 ```sh
-$ pip install pandas_access
+$ pip wheel .
+$ pip install pandas_access-0.0.1-py3-none-any.whl
 ```
 
 ## Usage

--- a/pandas_access/__init__.py
+++ b/pandas_access/__init__.py
@@ -34,7 +34,8 @@ def _extract_dtype(data_type):
     if data_type.startswith('double'):
         return np.float_
     elif data_type.startswith('long'):
-        return np.int_
+        #return np.int_
+        return 'Int64'
     else:
         return None
 

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
     description="A tiny, subprocess-based tool for reading a MS Access database(.rdb) as a Pandas DataFrame.",
     long_description=open(README_FILE).read(),
     data_files=['README.md'],
-    url="https://github.com/jbn/pandas_access"
+    url="https://github.com/bghimire2/pandas_access"
 )


### PR DESCRIPTION
Pandas default integer field produces an exception if any of the data values is NA. 
This pull request fixes this issue: see https://stackoverflow.com/questions/11548005/numpy-or-pandas-keeping-array-type-as-integer-while-having-a-nan-value