### PR TITLE
fix: more correct parcing columns for schema

### DIFF
--- a/pandas_access/__init__.py
+++ b/pandas_access/__init__.py
@@ -8,7 +8,7 @@ except ImportError:
     from io import BytesIO
 
 
-TABLE_RE = re.compile("CREATE TABLE \[(\w+)\]\s+\((.*?\));",
+TABLE_RE = re.compile("CREATE TABLE \[([^\]]+)\]\s*\(([^\;]*)\)\;",
                       re.MULTILINE | re.DOTALL)
 
 DEF_RE = re.compile("\s*\[(\w+)\]\s*([^,]*),?")

--- a/pandas_access/__init__.py
+++ b/pandas_access/__init__.py
@@ -11,7 +11,7 @@ except ImportError:
 TABLE_RE = re.compile("CREATE TABLE \[(\w+)\]\s+\((.*?\));",
                       re.MULTILINE | re.DOTALL)
 
-DEF_RE = re.compile("\s*\[(\w+)\]\s*(.*?),")
+DEF_RE = re.compile("\s*\[(\w+)\]\s*([^,]*),?")
 
 
 def list_tables(rdb_file, encoding="latin-1"):


### PR DESCRIPTION
Old code cant find field [reg] in test data for  _extract_defs(defs_str) 
defs_str = '''
	[fam]			Text (100), 
	[nam]			Text (100), 
	[fnm]			Text (100), 
	[dat]			DateTime, 
	[rod]			Text (510), 
	[gor]			Text (510), 
	[kod]			Long Integer, 
	[reg]			Text (300)
)
'''